### PR TITLE
Update compatibility to bevy v0.6.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,17 +1,13 @@
 [package]
 name = "bevy_prototype_inline_assets"
 description = "Bevy plugin for loading assets that are bundled into the binary."
-version = "0.1.1"
+version = "0.2.0"
 authors = ["Eitan Mosenkis <eitan@mosenkis.net>"]
-edition = "2018"
+edition = "2021"
 license = "MIT"
 license_file = "LICENSE"
 repository = "https://github.com/emosenkis/bevy_prototype_inline_assets"
 
 [dependencies]
-bevy_app = "0.3.0"
-bevy_asset = "0.3.0"
-bevy_ecs = "0.3.0"
-bevy_tasks = "0.3.0"
-bevy_utils = "0.3.0"
-futures = { version = "0.3", default_features = false }
+bevy = "0.6.1"
+futures = "0.3.21"

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 ## Status
 
-Works for the Bevy 0.3.0. See [Bevy issue
+Works for the Bevy 0.6.1. See [Bevy issue
 606](https://github.com/bevyengine/bevy/issues/606) and the linked PRs for
 discussion of native Bevy support for bundling assets.
 
@@ -24,7 +24,7 @@ cargo add bevy_prototype_inline_assets
 or, in your `Cargo.toml`:
 
 ``` toml
-bevy_prototype_inline_assets = "0.1.1"
+bevy_prototype_inline_assets = "0.2.0"
 ```
 
 ## Usage


### PR DESCRIPTION
Compiled and tested for the most recent bevy. As far as I know, this should work. It looks like a lot of the old crates got merged and a bunch of methods got moved around. It also looks like it's no longer necessary to code for platform-specific cases; the standard bevy methods should take care of it.